### PR TITLE
Convert (back) “self.profiles” to list if not already a list

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -95,6 +95,8 @@ class PocketBookToolsPlugin(InterfaceAction):
                     return
                 self.profiles = sqlite_execute_query(self.explorerdbpath,
                                                      query="SELECT name from profiles")  # tested v37
+                if not isinstance(self.profiles, list):
+                    self.profiles = [self.profiles]
                 self.profilepaths = getprofilepaths(self.profiles, self.mainpath, self.cardpath)
                 # alt: search for books.db. However, if count > 1 complexity becomes similar.
                 self.bookdbs = [(profile, os.path.join(path, 'books.db')) for profile, path in self.profilepaths]


### PR DESCRIPTION
HI,

After looking for the reason of the export of highlights was not working on my pocketbook color, I found out the profile management was not working as expected when there is only one profile.
I am proposing this fix, according the following reasons:

1. As `sqlite_execute_query` remplace the returned value by the item of the list if the sql request returned only one data, 
2. and as changing this behavior could lead to unexpected impact in other part of the code,
3. and as it is clear that `self.profiles` is expected to be a `list` and nothing else,

I choose to convert back to list if the profiles is not a list after asking for the profile list at device connection and not in `getprofilespaths()` `function.

I hope this change will help others.

Regards,